### PR TITLE
fix nested repo cloning bug when location is specified as a relative path

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     username = args.username
     password = args.password
     owner = args.team if args.team else username
-    location = args.location
+    location = os.path.abspath(args.location)
     _quiet = args.quiet
     _verbose = args.verbose
     _mirror = args.mirror


### PR DESCRIPTION
I discovered weird behavior when the location command line argument is specified as a relative path. Basically when it changes directory in `update_repo()` when location is specified as a relative path, it ends up nesting cloned repos that should only need to be updated inside of the first lexicographic repository :).