### PR TITLE
Pipes to nul instead of /dev/null for Windows users

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -45,7 +45,10 @@ def exec_cmd(command):
     global _verbose
     debug("Executing command: %s" % command)
     if not _verbose:
-        command = "%s > /dev/null 2>&1" % command
+        if 'nt' == os.name:
+            command = "%s > nul 2> nul" % command
+        else:
+            command = "%s > /dev/null 2>&1" % command
     resp = os.system(command)
     if resp != 0:
         exit("Command [%s] failed" % command, resp)


### PR DESCRIPTION
This allows Windows users to run the script without the verbose flag. Before, Windows users had to use the verbose flag to avoid piping to /dev/null, which doesn't make sense in Windows. I want to resolve #26 by piping to nul.