### PR TITLE
Use subprocess.call rather that os.system, so slower commands don't fail

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -2,6 +2,7 @@
 import argparse
 import datetime
 import os
+import subprocess
 import sys
 from getpass import getpass
 
@@ -61,7 +62,7 @@ def exec_cmd(command):
             command = "%s > nul 2> nul" % command
         else:
             command = "%s > /dev/null 2>&1" % command
-    resp = os.system(command)
+    resp = subprocess.call(command, shell=True)
     if resp != 0:
         exit("Command [%s] failed" % command, resp)
 


### PR DESCRIPTION
I noticed that running the script on a repo that has a big index and therefore takes a long time to clone makes the command fail when launched using **os.system**. This simple fix removes the error by using **subprocess.call** instead, which will correctly wait for the command, whatever the running time.